### PR TITLE
Using a deque instead of a list for a more performant data structure

### DIFF
--- a/simpleai/search/utils.py
+++ b/simpleai/search/utils.py
@@ -1,13 +1,14 @@
 # coding=utf-8
 import heapq
+from collections import deque
 from itertools import izip
 import random
 
 
-class FifoList(list):
-    '''List that pops from the begining.'''
-    def pop(self, index=0):
-        return super(FifoList, self).pop(index)
+class FifoList(deque):
+    '''List that pops from the beginning.'''
+    def pop(self):
+        return super(FifoList, self).popleft()
 
 
 class BoundedPriorityQueue(list):

--- a/tests/search/test_utils.py
+++ b/tests/search/test_utils.py
@@ -13,9 +13,7 @@ class TestFifoList(unittest.TestCase):
 
     def test_pop_returns_first_element(self):
         self.assertEquals(self.f.pop(), 1)
-
-    def test_pop_with_index_works(self):
-        self.assertEquals(self.f.pop(1), 2)
+        self.assertEquals(len(self.f), 2)
 
 
 class TestBoundedPriorityQueue(unittest.TestCase):


### PR DESCRIPTION
pop(0) incurs O(n) memory movements for python lists as opposed to deque from collections which can do it in O(1)
