### PR TITLE
Adding Arc Consistency (AC3) to CSP Backtracking 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ pip-log.txt
 
 # Vim tmps
 *.swp
+
+# Emacs backups
+*.*~

--- a/samples/search/sodoku.py
+++ b/samples/search/sodoku.py
@@ -1,0 +1,95 @@
+from StringIO import StringIO
+from string import uppercase
+from itertools import combinations
+from collections import OrderedDict
+
+from simpleai.search import (
+    CspProblem, backtrack, min_conflicts,
+    MOST_CONSTRAINED_VARIABLE, HIGHEST_DEGREE_VARIABLE,
+    LEAST_CONSTRAINING_VALUE)
+
+from simpleai.search.arc import arc_concistency_3
+
+
+variables = ["%s%d" % (i, j) for i in uppercase[:9] for j in xrange(1, 10)]
+
+domains = OrderedDict((v, range(1, 10)) for v in variables)
+
+
+def const_different(variables, values):
+    return values[0] != values[1]  # expect the value of the neighbors to be different
+
+sodoku = \
+"""
+  3 2 6
+9  3 5  1
+  18 64
+  81 29
+7       8
+  67 82
+  26 95
+8  2 3  9
+  5 1 3
+"""
+
+
+def parsepuzzle(puzzle):
+    sodoku_lines = map(lambda s: s.rstrip("\n"), StringIO(puzzle).readlines()[1:])
+    domains = {}
+
+    for k, i in enumerate(uppercase[:9]):
+        for j in xrange(1, 10):
+            line = sodoku_lines[k]
+            if len(line) <= (j - 1):
+                continue
+            val = line[j - 1]
+            if val != ' ':
+                var = "%s%d" % (i, j)
+                domains[var] = [int(val)]
+
+    return domains
+
+
+def mkconstraints():
+    constraints = []
+
+    for j in xrange(1, 10):
+        vars = ["%s%d" % (i, j) for i in uppercase[:9]]
+        constraints.extend((c, const_different) for c in combinations(vars, 2))
+
+    for i in uppercase[:9]:
+        vars = ["%s%d" % (i, j) for j in xrange(1, 10)]
+        constraints.extend((c, const_different) for c in combinations(vars, 2))
+
+    for b0 in ['ABC', 'DEF', 'GHI']:
+        for b1 in [[1, 2, 3], [4, 5, 6], [7, 8, 9]]:
+            vars = ["%s%d" % (i, j) for i in b0 for j in b1]
+            l = list((c, const_different) for c in combinations(vars, 2))
+            constraints.extend(l)
+
+    return constraints
+
+
+def display_solution(sol):
+    for i in uppercase[:9]:
+        print "|".join([str(sol["%s%d" % (i, j)]) for j in xrange(1, 10)])
+        print "-|-|-|-|-|-|-|-|-"
+
+constraints = mkconstraints()
+domains.update(parsepuzzle(sodoku))
+
+#arc_concistency_3(domains, constraints)
+my_problem = CspProblem(variables, domains, constraints)
+sol = backtrack(my_problem)
+display_solution(sol)
+
+
+# sol = backtrack(my_problem, variable_heuristic=MOST_CONSTRAINED_VARIABLE, value_heuristic=LEAST_CONSTRAINING_VALUE)
+# display_solution(sol)
+
+# print backtrack(my_problem, variable_heuristic=MOST_CONSTRAINED_VARIABLE)
+# print backtrack(my_problem, variable_heuristic=HIGHEST_DEGREE_VARIABLE)
+# print backtrack(my_problem, value_heuristic=LEAST_CONSTRAINING_VALUE)
+# print backtrack(my_problem, variable_heuristic=MOST_CONSTRAINED_VARIABLE, value_heuristic=LEAST_CONSTRAINING_VALUE)
+# print backtrack(my_problem, variable_heuristic=HIGHEST_DEGREE_VARIABLE, value_heuristic=LEAST_CONSTRAINING_VALUE)
+# print min_conflicts(my_problem)

--- a/simpleai/search/arc.py
+++ b/simpleai/search/arc.py
@@ -1,0 +1,129 @@
+from collections import deque
+from operator import itemgetter
+
+
+# The first 3 functions are exported for testing purposes.
+__all__ = ['constraint_wrapper', 'neighbors', 'all_arcs', 'revise', 'arc_concistency_3']
+
+fst = itemgetter(0)
+
+
+def constraint_wrapper(vars_, constraint):
+    '''
+    Returns a callable that switches the values argument of @constraint
+    acording to the varibles passed to the wrapper returned.
+
+    @constraint is a callable representing the constraint between @vars_.
+
+    Say @vars_ have (X_i, X_j) because we assume the constraint to be
+    symmetrical, that is constraint must apply to (X_j, X_i) we need
+    to be able to call constraint with the values swapped, according to
+    how the variables of the constraint are.
+    '''
+    X_i, X_j = vars_
+
+    def wrapper(variables, values):
+        if variables == (X_i, X_j):
+            return constraint(variables, values)
+        elif variables == (X_j, X_i):
+            return constraint(variables, (values[1], values[0]))
+        else:
+            raise ValueError("This constraint does not work with %s", ", ".join(vars_))
+    return wrapper
+
+
+def neighbors(xi, constraints, exclude):
+    '''
+    Returns all variables that are related, through a constraint, to @xi
+
+    @constraints is a list of tuples, each tuple having
+    a tuple of variables and a callable which serves as
+    the constraint between the variables. e.g:
+
+    [(('X', 'Y'), lambda vars, values: values[0] == values[1]), .. ]
+
+    If the constraint was as above, 'Y' would be a neighbor of 'X'.
+    '''
+    def _neighbor(variables):
+        idx_i = variables.index(xi)
+        idx_j = 1 - idx_i
+        neighbor = variables[idx_j]
+        return neighbor
+
+    seen = set()
+    for t in constraints:
+        variables, func = t
+
+        if len(variables) != 2:  # ignore constraints that are not binary
+            continue
+
+        if not xi in variables:
+            continue
+        xk = _neighbor(variables)
+        if xk == exclude:
+            continue
+        if xk in seen:
+            continue
+        seen.add(xk)
+        yield ((xk, xi), func)
+
+
+def revise(domains, variables, constraint):
+    """
+    Expects the domains to be specified in a list
+    """
+    xi, xj = variables
+    di = domains[xi]  # domain of variable X_i
+    dj = domains[xj]  # domain of variable X_j
+    revised = False
+
+    for x in di:
+        if not any(constraint(variables, (x, y))  # constraint is a callable
+                   for y in dj):
+            di.remove(x)
+            revised = True
+    return revised
+
+
+def all_arcs(constraints):
+    seen = set()
+    seen_add = seen.add
+    for vars_, const in constraints:
+        try:
+            x, y = vars_
+        except ValueError:
+            continue
+
+        # arcs
+        fwd = (x, y)
+        bck = (y, x)
+
+        wrapped = constraint_wrapper(vars_, const)
+
+        if not fwd in seen:
+            yield (fwd, wrapped)
+
+        if not bck in seen:
+            yield (bck, wrapped)
+
+        map(seen_add, (fwd, bck))
+
+
+def arc_concistency_3(domains, constraints):
+    """
+    Makes a CSP problem arc concistent.
+
+    Assumes that the constraints are symmetrical, that is:
+       constraint(x, y) == constraint(y, x).
+    """
+    arcs = deque(all_arcs(constraints))
+
+    while arcs:
+        variables, func = arcs.popleft()
+        xi, xj = variables
+        if revise(domains, variables, func):
+            if len(domains[xi]) == 0:
+                return False
+            for arc in neighbors(xi, constraints, xj):
+                arcs.append(arc)
+    return True

--- a/simpleai/search/csp.py
+++ b/simpleai/search/csp.py
@@ -69,6 +69,7 @@ def _count_conflicts(problem, assignment, variable=None, value=None):
     '''
     return len(_find_conflicts(problem, assignment, variable, value))
 
+
 def _find_conflicts(problem, assignment, variable=None, value=None):
     '''
     Find violated constraints on a given assignment, with the possibility
@@ -119,6 +120,7 @@ def _backtracking(problem, assignment, domains, variable_chooser,
     '''
     Internal recursive backtracking algorithm.
     '''
+    from arc import arc_concistency_3
     if len(assignment) == len(problem.variables):
         return assignment
 
@@ -132,18 +134,18 @@ def _backtracking(problem, assignment, domains, variable_chooser,
         new_assignment = deepcopy(assignment)
         new_assignment[variable] = value
 
-        if not _count_conflicts(problem, new_assignment): # TODO on aima also checks if using fc
+        if not _count_conflicts(problem, new_assignment):  # TODO on aima also checks if using fc
             new_domains = deepcopy(domains)
+            new_domains[variable] = [value]
 
-            # TODO propagation and inferences
-
-            result = _backtracking(problem,
-                                   new_assignment,
-                                   new_domains,
-                                   variable_chooser,
-                                   values_sorter)
-            if result:
-                return result
+            if arc_concistency_3(new_domains, problem.constraints):
+                result = _backtracking(problem,
+                                       new_assignment,
+                                       new_domains,
+                                       variable_chooser,
+                                       values_sorter)
+                if result:
+                    return result
 
     return None
 

--- a/tests/search/test_arc_concistency.py
+++ b/tests/search/test_arc_concistency.py
@@ -1,0 +1,91 @@
+# coding=utf-8
+import unittest
+
+from operator import itemgetter
+
+from simpleai.search.arc import constraint_wrapper, neighbors, all_arcs, revise, arc_concistency_3
+
+fst = itemgetter(0)
+
+
+class TestNeighborsAndArcs(unittest.TestCase):
+
+    def setUp(self):
+        unit = self.unit = lambda vars_, values: False
+        self.constraints = [(('A1', 'B2'), unit),
+                            (('A1', 'C2'), unit),
+                            (('D2', 'A1'), unit),
+                            (('D2', 'C1'), unit),
+                            (('E2', 'A1'), unit)]
+
+    def test_neighbors(self):
+        variables = map(lambda t: fst(fst(t)), neighbors('A1', self.constraints, 'B2'))
+        self.assertEqual(set(variables), set(['C2', 'D2', 'E2']))
+
+    def test_all_arcs(self):
+        # does not check that the constraint function is well created
+        variables = map(fst, list(all_arcs(self.constraints)))
+        arcs = [('A1', 'B2'),
+                ('B2', 'A1'),
+                ('A1', 'C2'),
+                ('C2', 'A1'),
+                ('D2', 'A1'),
+                ('A1', 'D2'),
+                ('D2', 'C1'),
+                ('C1', 'D2'),
+                ('E2', 'A1'),
+                ('A1', 'E2')]
+        self.assertEqual(variables, arcs)
+
+    def test_constraint_wrapper(self):
+        constraint = (('X', 'Y'), lambda vars_, values: values[0] ** 2 == values[1])
+        wrapped = constraint_wrapper(*constraint)
+        self.assertTrue(wrapped(('Y', 'X'), (25, 5)))
+
+    def test_constraint_wrapper_raises_error(self):
+        constraint = (('X', 'Y'), lambda vars_, values: values[0] ** 2 == values[1])
+        wrapped = constraint_wrapper(*constraint)
+        self.assertRaises(ValueError, wrapped, ('Y', 'Z'), (25, 5))
+
+
+class TestReviseDomain(unittest.TestCase):
+
+    def set_domains(self):
+        self.domains = {'X': [1, 2, 3, 4, 5],
+                        'Y': [1, 4, 9, 16, 20]}
+
+    def setUp(self):
+        self.set_domains()
+        const = lambda vars_, values: values[0] ** 2 == values[1]
+        self.constraint = constraint_wrapper(('X', 'Y'), const)
+
+    def tearDown(self):
+        self.set_domains()
+
+    def test_revise_X(self):
+        self.assertTrue(revise(self.domains, ('X', 'Y'), self.constraint))
+        self.assertEqual(self.domains['X'], [1, 2, 3, 4])
+        self.assertEqual(self.domains['Y'], [1, 4, 9, 16, 20])
+
+    def test_revise_Y(self):
+        self.assertTrue(revise(self.domains, ('Y', 'X'), self.constraint))
+        self.assertEqual(self.domains['X'], [1, 2, 3, 4, 5])
+        self.assertEqual(self.domains['Y'], [1, 4, 9, 16])
+
+
+class TestAC3(unittest.TestCase):
+
+    def set_domains(self):
+        self.domains = {'X': [1, 2, 3, 4, 5],
+                        'Y': [1, 4, 9, 16, 20]}
+
+    def set_constraints(self):
+        self.constraints = [(('X', 'Y'), lambda vars_, values: values[0] ** 2 == values[1])]
+
+    def setUp(self):
+        self.set_domains()
+        self.set_constraints()
+
+    def test_ac3(self):
+        self.assertTrue(arc_concistency_3(self.domains, self.constraints))
+        self.assertEqual(self.domains, {'X': [1, 2, 3, 4], 'Y': [1, 4, 9, 16]})


### PR DESCRIPTION
Only binary constraints are used for arc consistency in CPS
