### PR TITLE
Make BoundedPriorityQueue use internal heap instead of subclassing from list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ pip-log.txt
 
 # Emacs backups
 *.*~
+# Idea files/directory
+.idea
+*.iml

--- a/simpleai/search/utils.py
+++ b/simpleai/search/utils.py
@@ -11,18 +11,24 @@ class FifoList(deque):
         return super(FifoList, self).popleft()
 
 
-class BoundedPriorityQueue(list):
+class BoundedPriorityQueue(object):
     def __init__(self, limit=None, *args):
         self.limit = limit
-        super(BoundedPriorityQueue, self).__init__(*args)
+        self.queue = list()
+
+    def __getitem__(self, val):
+        return self.queue[val]
+
+    def __len__(self):
+        return len(self.queue)
 
     def append(self, x):
-        heapq.heappush(self, x)
-        if self.limit and len(self) > self.limit:
-            self.remove(heapq.nlargest(1, self)[0])
+        heapq.heappush(self.queue, x)
+        if self.limit and len(self.queue) > self.limit:
+            self.queue.remove(heapq.nlargest(1, self.queue)[0])
 
     def pop(self):
-        return heapq.heappop(self)
+        return heapq.heappop(self.queue)
 
     def extend(self, iterable):
         for x in iterable:
@@ -30,7 +36,7 @@ class BoundedPriorityQueue(list):
 
     def clear(self):
         for x in self:
-            self.remove(x)
+            self.queue.remove(x)
 
 
 class InverseTransformSampler(object):


### PR DESCRIPTION
Added missing methods ( **len** & **getitem** ) to changes proposed by @asbxrm

Asbjørn Bjørnstad said:

> The python version of heapq.heappush starts by calling heap.append(item), with BoundedPriorityQueue calling ?> > heappush in it's append function the end result is endless recursion.
> 
> Cpython uses a c implementation of heapq, which doesn't have this issue (Apparently). But other impementations > may use the python version, pypy is the one I tried where this issue appears.
