### PR TITLE
Added missing method on BoundedPriorityQueue

### DIFF
--- a/simpleai/search/utils.py
+++ b/simpleai/search/utils.py
@@ -38,6 +38,9 @@ class BoundedPriorityQueue(object):
         for x in self:
             self.queue.remove(x)
 
+    def remove(self, x):
+        self.queue.remove(x)
+
 
 class InverseTransformSampler(object):
     def __init__(self, weights, objects):


### PR DESCRIPTION
When _search is called with graph_replace_when_better=True, and the node expanded (<n>) is better that the <other> one in the fringe it tries to remove it but fails.
