### PR TITLE
Fix py3 web viewer

### DIFF
--- a/simpleai/search/models.py
+++ b/simpleai/search/models.py
@@ -7,7 +7,7 @@ class SearchProblem(object):
        In this class, the search space is meant to be represented implicitly as
        a graph.
        Each state corresponds with a problem state (ie, a valid configuration)
-       and each problem action (ie, a valid transformation to a configuracion)
+       and each problem action (ie, a valid transformation to a configuration)
        corresponds with an edge.
 
        To use this class you should implement the methods required by the search

--- a/simpleai/search/models.py
+++ b/simpleai/search/models.py
@@ -128,6 +128,9 @@ class SearchNode(object):
     def __eq__(self, other):
         return isinstance(other, SearchNode) and self.state == other.state
 
+    def __hash__(self):
+        return hash(self.state)
+
     def state_representation(self):
         return self.problem.state_representation(self.state)
 


### PR DESCRIPTION
The web viewer stopped working after the py3 migration.
On py3 when __eq__() is defined __hash__() is implicitly set to None. That throws an unhashable type error after clicking play on the web viewer.

I've defined it to return the hash of the state but maybe it could be set to 0 to reduce computation time.