### PR TITLE
Fix simulated annealing random chance calculation

### DIFF
--- a/simpleai/search/local.py
+++ b/simpleai/search/local.py
@@ -185,7 +185,7 @@ def _create_simulated_annealing_expander(schedule):
         if neighbors:
             succ = random.choice(neighbors)
             delta_e = succ.value - current.value
-            if delta_e > 0 or random.random() < math.exp(delta_e / T):
+            if delta_e > 0 or random.random() < math.exp(- delta_e / T):
                 fringe.pop()
                 fringe.append(succ)
 


### PR DESCRIPTION
Exponential function only returns "probabilities" - i.e. numbers between [0,1) - with negative values.